### PR TITLE
Update ajax.php

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -151,7 +151,7 @@ class ajax_indexmenu_plugin {
 		require_once(DOKU_PLUGIN.'indexmenu/syntax/indexmenu.php');
 		global $conf;
 		$idxm=new syntax_plugin_indexmenu_indexmenu();
-		$ns=$idxm->_parse_ns($ns);
+		$ns=$idxm->_parse_ns(rawurldecode($ns));
 		$level=-1;
 		$max=0;
 		$data = array();


### PR DESCRIPTION
It doesn't work for UTF8 text filenames. So Samuele(pre-MASTER) fix that problem, but he doesn't patch sourcefile. Please patch that default.
