### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -30,7 +30,7 @@ class action_plugin_indexmenu extends DokuWiki_Action_Plugin {
 	/*
 	 * plugin should use this method to register its handlers with the dokuwiki's event controller
 	*/
-	function register(&$controller) {
+	function register(Doku_Event_Handler $controller) {
 		if ($this->getConf('only_admins')) $controller->register_hook('IO_WIKIPAGE_WRITE', 'BEFORE',  $this, '_checkperm');
 		if ($this->getConf('page_index') != '') $controller->register_hook('TPL_ACT_RENDER', 'BEFORE', $this, '_loadindex');
 		$controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_hookjs');

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -79,7 +79,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Handle the match
 	 */
-	function handle($match, $state, $pos, &$handler){
+	function handle($match, $state, $pos, Doku_Handler $handler){
 		$theme="default";
 		$ns=".";
 		$level = -1;
@@ -194,7 +194,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Render output
 	 */
-	function render($mode, &$renderer, $data) {
+	function render($mode, Doku_Renderer $renderer, $data) {
 		global $ACT;
 		global $conf;
 		global $INFO;

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -57,7 +57,7 @@ class syntax_plugin_indexmenu_tag extends DokuWiki_Syntax_Plugin {
   /**
    * Handle the match
    */
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
     $match = substr($match,14,-2);
     return array($match);
   }
@@ -65,7 +65,7 @@ class syntax_plugin_indexmenu_tag extends DokuWiki_Syntax_Plugin {
   /**
    * Render output
    */
-  function render($mode, &$renderer, $data) {
+  function render($mode, Doku_Renderer $renderer, $data) {
     if (is_numeric($data[0])) $renderer->meta['indexmenu_n'] = $data[0];;
   }
 }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
